### PR TITLE
Handle asprintf return value

### DIFF
--- a/src/shared/shell.c
+++ b/src/shared/shell.c
@@ -563,6 +563,7 @@ void bt_shell_prompt_input(const char *label, const char *msg,
 			bt_shell_prompt_input_func func, void *user_data)
 {
 	char *str;
+	int len;
 
 	if (!data.init || data.mode)
 		return;
@@ -575,7 +576,13 @@ void bt_shell_prompt_input(const char *label, const char *msg,
 	data.saved_prompt = true;
 	data.saved_func = func;
 	data.saved_user_data = user_data;
-	asprintf(&str, "[%s] %s ", label, msg);
+	len = asprintf(&str, "[%s] %s ", label, msg);
+	if (len < 0) {
+		str = NULL;
+		free(msg); /* Either corrupted event or no memory */
+		return;
+	}
+
 
 	rl_save_prompt();
 	bt_shell_set_prompt(str);


### PR DESCRIPTION
Some compilers may throw a warn_unused_return if asprintf() return value is not
handled, this will trigger compilation error [-Werror=unused-result].

Signed-off-by: Pedro Soares <hspedro@profusion.mobi>